### PR TITLE
Path, output and comment updates for script files.

### DIFF
--- a/share/install/InstallScript.sh
+++ b/share/install/InstallScript.sh
@@ -3,7 +3,7 @@
 
 # Installation script for MORIS 
 
-# tested on: ubuntu; OpenSUSE 15.5 
+# tested on: Ubuntu; OpenSUSE 15.5; Fedora 41
 
 # For special cases, such as building openmpi with scheduler, 
 # see moris/share/install/Install_Step_By_Step.txt

--- a/share/install/Install_Step_By_Step.txt
+++ b/share/install/Install_Step_By_Step.txt
@@ -8,7 +8,7 @@
 * This installation is based on spack.
 *
 * The instructions have been tested for OPENSuse 15.x.x 
-* and Ubuntu 22.04.1
+* Ubuntu 22.04.1 and Fedora 41.
 *
 * Note: The installation process uses tcsh
 *------------------------------------------------------------

--- a/share/scripts/create_shared_object.sh
+++ b/share/scripts/create_shared_object.sh
@@ -61,7 +61,7 @@ if [ "$2" ];then
     builddir=$2
 
     if [ ! -d "$MORISROOT/$builddir" ];then
-       echo " Error: $workdir does not exist"
+       echo " Error: $MORISROOT/$builddir does not exist"
        echo ""
        exit
     fi

--- a/share/scripts/create_shared_object.sh
+++ b/share/scripts/create_shared_object.sh
@@ -167,7 +167,7 @@ if [ "$dbgflag" = '0' ];then
         echo " restoring input_file.cpp from git repository"
         echo ""
     
-        cd "$MORISROOT/$builddir"
+        cd "$MORISROOT"
         git checkout -- "$MORISROOT/projects/mains/input_file.cpp"
     fi
 else


### PR DESCRIPTION
Fixes minor issues I stumbled open when setting up MORIS on a Fedora 41 machine:

- 896d61e421701afef86f6b2471ce6ab0193c7c4c: Fixes error message for non-existing build directory when trying to compile a input file using the _moris.sh_ script.
- 8a1d1a7bf2168d77840150e61dd2fe00c4a0d873: Fixes path for git checkout when restoring _input_file.cpp_ after compiling a input file with the _moris.sh_ script.
- c2cf205eb97dd61071d979a594077be790748bcb: Adds Fedora 41 to the list of working operating systems